### PR TITLE
Build Key by name

### DIFF
--- a/src/test/scala/org/sandbox/example/EnumMarshalingSpec.scala
+++ b/src/test/scala/org/sandbox/example/EnumMarshalingSpec.scala
@@ -8,14 +8,18 @@ object EnumMarshalingSpec {
     def Key: Class[_]
   }
 
-  sealed abstract class FlagX(val code: Int, val Key: Class[_] = FlagX.Key) extends Flag //with EnumEntry
+  sealed abstract class FlagX(val code: Int, buildKey: => Class[_] = FlagX.Key) extends Flag {
+    lazy val Key = buildKey
+  } //with EnumEntry
   object FlagX extends Enum[FlagX] {
     val values = findValues
     case object Off extends FlagX(0)
     case object On  extends FlagX(1)
     def Key = classOf[FlagX]
   }
-  sealed abstract class FlagY(val code: Int, val Key: Class[_] = FlagY.Key) extends Flag //with EnumEntry
+  sealed abstract class FlagY(val code: Int, buildKey: => Class[_] = FlagY.Key) extends Flag {
+    lazy val Key = buildKey
+  }//with EnumEntry
   object FlagY extends Enum[FlagY] {
     val values = findValues
     case object Disable extends FlagY(0)


### PR DESCRIPTION
The `Key` parameter for `FlagX` and `FlagY` had a default parameter that was dependent on the initialisation of their companion objects. This created a circular dependency that I'm breaking here by using a by-name parameter that is memoised on first access.